### PR TITLE
First attempt at converting to a PHP 5 package

### DIFF
--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -1,7 +1,7 @@
 <?php
 /* vim: set expandtab softtabstop=4 tabstop=4 shiftwidth=4: */
 // +----------------------------------------------------------------------+
-// | PHP Version 4                                                        |
+// | PHP Version 5                                                        |
 // +----------------------------------------------------------------------+
 // | Copyright (c) 1997-2003 The PHP Group                                |
 // +----------------------------------------------------------------------+
@@ -19,6 +19,7 @@
 // +----------------------------------------------------------------------+
 
 require_once 'PEAR.php';
+require_once 'PEAR/Exception.php';
 require_once 'Net/Socket.php';
 
 /**
@@ -36,31 +37,31 @@ class Net_SMTP
 {
     /**
      * The server to connect to.
+     *
      * @var string
-     * @access public
      */
-    var $host = 'localhost';
+    public $host = 'localhost';
 
     /**
      * The port to connect to.
+     *
      * @var int
-     * @access public
      */
-    var $port = 25;
+    public $port = 25;
 
     /**
      * The value to give when sending EHLO or HELO.
+     *
      * @var string
-     * @access public
      */
-    var $localhost = 'localhost';
+    public $localhost = 'localhost';
 
     /**
      * List of supported authentication methods, in preferential order.
+     *
      * @var array
-     * @access public
      */
-    var $auth_methods = array();
+    public $auth_methods = array();
 
     /**
      * Use SMTP command pipelining (specified in RFC 2920) if the SMTP
@@ -71,80 +72,80 @@ class Net_SMTP
      * SMTP server but return immediately.
      *
      * @var bool
-     * @access public
      */
-    var $pipelining = false;
+    public $pipelining = false;
 
     /**
      * Number of pipelined commands.
+     *
      * @var int
-     * @access private
      */
-    var $_pipelined_commands = 0;
+    protected $_pipelined_commands = 0;
 
     /**
      * Should debugging output be enabled?
+     *
      * @var boolean
-     * @access private
      */
-    var $_debug = false;
+    protected $_debug = false;
 
     /**
      * Debug output handler.
+     *
      * @var callback
-     * @access private
      */
-    var $_debug_handler = null;
+    protected $_debug_handler = null;
 
     /**
      * The socket resource being used to connect to the SMTP server.
+     *
      * @var resource
-     * @access private
      */
-    var $_socket = null;
+    protected $_socket = null;
 
     /**
      * Array of socket options that will be passed to Net_Socket::connect().
+     *
      * @see stream_context_create()
+     *
      * @var array
-     * @access private
      */
-    var $_socket_options = null;
+    protected $_socket_options = null;
 
     /**
      * The socket I/O timeout value in seconds.
+     *
      * @var int
-     * @access private
      */
-    var $_timeout = 0;
+    protected $_timeout = 0;
 
     /**
      * The most recent server response code.
+     *
      * @var int
-     * @access private
      */
-    var $_code = -1;
+    protected $_code = -1;
 
     /**
      * The most recent server response arguments.
+     *
      * @var array
-     * @access private
      */
-    var $_arguments = array();
+    protected $_arguments = array();
 
     /**
      * Stores the SMTP server's greeting string.
+     *
      * @var string
-     * @access private
      */
-    var $_greeting = null;
+    protected $_greeting = null;
 
     /**
      * Stores detected features of the SMTP server.
+     *
      * @var array
-     * @access private
      */
-    var $_esmtp = array();
+    protected $_esmtp = array();
 
     /**
      * Instantiates a new Net_SMTP object, overriding any defaults
@@ -163,12 +164,10 @@ class Net_SMTP
      * @param boolean $pipeling   Use SMTP command pipelining
      * @param integer $timeout    Socket I/O timeout in seconds.
      * @param array   $socket_options Socket stream_context_create() options.
-     *
-     * @access  public
-     * @since   1.0
      */
-    function Net_SMTP($host = null, $port = null, $localhost = null,
-        $pipelining = false, $timeout = 0, $socket_options = null)
+    public function __construct($host = null, $port = null, $localhost = null,
+                                $pipelining = false, $timeout = 0,
+                                $socket_options = null)
     {
         if (isset($host)) {
             $this->host = $host;
@@ -185,7 +184,7 @@ class Net_SMTP
         $this->_socket_options = $socket_options;
         $this->_timeout = $timeout;
 
-        /* Include the Auth_SASL package.  If the package is available, we 
+        /* Include the Auth_SASL package.  If the package is available, we
          * enable the authentication methods that depend upon it. */
         if (@include_once 'Auth/SASL.php') {
             $this->setAuthMethod('CRAM-MD5', array($this, '_authCram_MD5'));
@@ -200,25 +199,20 @@ class Net_SMTP
     /**
      * Set the socket I/O timeout value in seconds plus microseconds.
      *
-     * @param   integer $seconds        Timeout value in seconds.
-     * @param   integer $microseconds   Additional value in microseconds.
-     *
-     * @access  public
-     * @since   1.5.0
+     * @param integer $seconds       Timeout value in seconds.
+     * @param integer $microseconds  Additional value in microseconds.
      */
-    function setTimeout($seconds, $microseconds = 0) {
+    public function setTimeout($seconds, $microseconds = 0)
+    {
         return $this->_socket->setTimeout($seconds, $microseconds);
     }
 
     /**
      * Set the value of the debugging flag.
      *
-     * @param   boolean $debug      New value for the debugging flag.
-     *
-     * @access  public
-     * @since   1.1.0
+     * @param boolean $debug  New value for the debugging flag.
      */
-    function setDebug($debug, $handler = null)
+    public function setDebug($debug, $handler = null)
     {
         $this->_debug = $debug;
         $this->_debug_handler = $handler;
@@ -227,12 +221,9 @@ class Net_SMTP
     /**
      * Write the given debug text to the current debug output handler.
      *
-     * @param   string  $message    Debug mesage text.
-     *
-     * @access  private
-     * @since   1.3.3
+     * @param string $message  Debug message text.
      */
-    function _debug($message)
+    protected function _debug($message)
     {
         if ($this->_debug) {
             if ($this->_debug_handler) {
@@ -247,23 +238,21 @@ class Net_SMTP
     /**
      * Send the given string of data to the server.
      *
-     * @param   string  $data       The string of data to send.
+     * @param string $data  The string of data to send.
      *
-     * @return  mixed   The number of bytes that were actually written,
-     *                  or a PEAR_Error object on failure.
-     *
-     * @access  private
-     * @since   1.1.0
+     * @return integer  The number of bytes that were actually written.
+     * @throws PEAR_Exception
      */
-    function _send($data)
+    protected function _send($data)
     {
         $this->_debug("Send: $data");
 
         $result = $this->_socket->write($data);
-        if (!$result || PEAR::isError($result)) {
-            $msg = ($result) ? $result->getMessage() : "unknown error";
-            return PEAR::raiseError("Failed to write to socket: $msg",
-                                    null, PEAR_ERROR_RETURN);
+        if (!$result) {
+            throw new PEAR_Exception('Failed to write to socket: unknown error');
+        } elseif (PEAR::isError($result)) {
+            throw new PEAR_Exception('Failed to write to socket: ' . $result->getMessage(),
+                                     $result);
         }
 
         return $result;
@@ -277,24 +266,21 @@ class Net_SMTP
      * already contains any newline characters. Use _send() for
      * commands that must contain newlines.
      *
-     * @param   string  $command    The SMTP command to send to the server.
-     * @param   string  $args       A string of optional arguments to append
-     *                              to the command.
+     * @param string $command  The SMTP command to send to the server.
+     * @param string $args     A string of optional arguments to append
+     *                         to the command.
      *
-     * @return  mixed   The result of the _send() call.
-     *
-     * @access  private
-     * @since   1.1.0
+     * @return integer  The number of bytes that were actually written.
+     * @throws PEAR_Exception
      */
-    function _put($command, $args = '')
+    protected function _put($command, $args = '')
     {
         if (!empty($args)) {
             $command .= ' ' . $args;
         }
 
         if (strcspn($command, "\r\n") !== strlen($command)) {
-            return PEAR::raiseError('Commands cannot contain newlines',
-                                    null, PEAR_ERROR_RETURN);
+            throw new PEAR_Exception('Commands cannot contain newlines');
         }
 
         return $this->_send($command . "\r\n");
@@ -304,40 +290,35 @@ class Net_SMTP
      * Read a reply from the SMTP server.  The reply consists of a response
      * code and a response message.
      *
-     * @param   mixed   $valid      The set of valid response codes.  These
-     *                              may be specified as an array of integer
-     *                              values or as a single integer value.
-     * @param   bool    $later      Do not parse the response now, but wait
-     *                              until the last command in the pipelined
-     *                              command group
+     * @see getResponse
      *
-     * @return  mixed   True if the server returned a valid response code or
-     *                  a PEAR_Error object is an error condition is reached.
+     * @param mixed $valid  The set of valid response codes.  These
+     *                      may be specified as an array of integer
+     *                      values or as a single integer value.
+     * @param bool $later   Do not parse the response now, but wait
+     *                      until the last command in the pipelined
+     *                      command group
      *
-     * @access  private
-     * @since   1.1.0
-     *
-     * @see     getResponse
+     * @throws PEAR_Exception
      */
-    function _parseResponse($valid, $later = false)
+    protected function _parseResponse($valid, $later = false)
     {
         $this->_code = -1;
         $this->_arguments = array();
 
         if ($later) {
-            $this->_pipelined_commands++;
-            return true;
+            ++$this->_pipelined_commands;
+            return;
         }
 
-        for ($i = 0; $i <= $this->_pipelined_commands; $i++) {
+        for ($i = 0; $i <= $this->_pipelined_commands; ++$i) {
             while ($line = $this->_socket->readLine()) {
                 $this->_debug("Recv: $line");
 
                 /* If we receive an empty line, the connection was closed. */
                 if (empty($line)) {
                     $this->disconnect();
-                    return PEAR::raiseError('Connection was closed',
-                                            null, PEAR_ERROR_RETURN);
+                    throw new PEAR_Exception('Connection was closed');
                 }
 
                 /* Read the code and store the rest in the arguments array. */
@@ -362,52 +343,39 @@ class Net_SMTP
         $this->_pipelined_commands = 0;
 
         /* Compare the server's response code with the valid code/codes. */
-        if (is_int($valid) && ($this->_code === $valid)) {
-            return true;
-        } elseif (is_array($valid) && in_array($this->_code, $valid, true)) {
-            return true;
+        if ((is_int($valid) && ($this->_code === $valid)) ||
+            (is_array($valid) && in_array($this->_code, $valid, true))) {
+            return;
         }
 
-        return PEAR::raiseError('Invalid response code received from server',
-                                $this->_code, PEAR_ERROR_RETURN);
+        throw new PEAR_Exception('Invalid response code received from server',
+                                 $this->_code);
     }
 
     /**
      * Issue an SMTP command and verify its response.
      *
-     * @param   string  $command    The SMTP command string or data.
-     * @param   mixed   $valid      The set of valid response codes.  These
-     *                              may be specified as an array of integer
-     *                              values or as a single integer value.
+     * @param string $command  The SMTP command string or data.
+     * @param mixed $valid     The set of valid response codes.  These
+     *                         may be specified as an array of integer
+     *                         values or as a single integer value.
      *
-     * @return  mixed   True on success or a PEAR_Error object on failure.
-     *
-     * @access  public
-     * @since   1.6.0
+     * @throws PEAR_Exception
      */
-    function command($command, $valid)
+    public function command($command, $valid)
     {
-        if (PEAR::isError($error = $this->_put($command))) {
-            return $error;
-        }
-        if (PEAR::isError($error = $this->_parseResponse($valid))) {
-            return $error;
-        }
-
-        return true;
+        $this->_put($command);
+        $this->_parseResponse($valid);
     }
 
     /**
      * Return a 2-tuple containing the last response from the SMTP server.
      *
-     * @return  array   A two-element array: the first element contains the
-     *                  response code as an integer and the second element
-     *                  contains the response's arguments as a string.
-     *
-     * @access  public
-     * @since   1.1.0
+     * @return array  A two-element array: the first element contains the
+     *                response code as an integer and the second element
+     *                contains the response's arguments as a string.
      */
-    function getResponse()
+    public function getResponse()
     {
         return array($this->_code, join("\n", $this->_arguments));
     }
@@ -415,13 +383,10 @@ class Net_SMTP
     /**
      * Return the SMTP server's greeting string.
      *
-     * @return  string  A string containing the greeting string, or null if a 
+     * @return  string  A string containing the greeting string, or null if a
      *                  greeting has not been received.
-     *
-     * @access  public
-     * @since   1.3.3
      */
-    function getGreeting()
+    public function getGreeting()
     {
         return $this->_greeting;
     }
@@ -429,109 +394,79 @@ class Net_SMTP
     /**
      * Attempt to connect to the SMTP server.
      *
-     * @param   int     $timeout    The timeout value (in seconds) for the
-     *                              socket connection attempt.
-     * @param   bool    $persistent Should a persistent socket connection
-     *                              be used?
+     * @param int $timeout      The timeout value (in seconds) for the
+     *                          socket connection attempt.
+     * @param bool $persistent  Should a persistent socket connection
+     *                          be used?
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     * @access public
-     * @since  1.0
+     * @throws PEAR_Exception
      */
-    function connect($timeout = null, $persistent = false)
+    public function connect($timeout = null, $persistent = false)
     {
         $this->_greeting = null;
         $result = $this->_socket->connect($this->host, $this->port,
                                           $persistent, $timeout,
                                           $this->_socket_options);
         if (PEAR::isError($result)) {
-            return PEAR::raiseError('Failed to connect socket: ' .
-                                    $result->getMessage());
+            throw new PEAR_Exception('Failed to connect socket: ' . $result->getMessage(),
+                                     $result);
         }
 
-        /*
-         * Now that we're connected, reset the socket's timeout value for 
-         * future I/O operations.  This allows us to have different socket 
-         * timeout values for the initial connection (our $timeout parameter) 
-         * and all other socket operations.
-         */
+        /* Now that we're connected, reset the socket's timeout value for
+         * future I/O operations.  This allows us to have different socket
+         * timeout values for the initial connection (our $timeout parameter)
+         * and all other socket operations. */
         if ($this->_timeout > 0) {
-            if (PEAR::isError($error = $this->setTimeout($this->_timeout))) {
-                return $error;
-            }
+            $this->setTimeout($this->_timeout);
         }
 
-        if (PEAR::isError($error = $this->_parseResponse(220))) {
-            return $error;
-        }
+        $this->_parseResponse(220);
 
         /* Extract and store a copy of the server's greeting string. */
         list(, $this->_greeting) = $this->getResponse();
 
-        if (PEAR::isError($error = $this->_negotiate())) {
-            return $error;
-        }
-
-        return true;
+        $this->_negotiate();
     }
 
     /**
      * Attempt to disconnect from the SMTP server.
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     * @access public
-     * @since  1.0
+     * @throws PEAR_Exception
      */
-    function disconnect()
+    public function disconnect()
     {
-        if (PEAR::isError($error = $this->_put('QUIT'))) {
-            return $error;
-        }
-        if (PEAR::isError($error = $this->_parseResponse(221))) {
-            return $error;
-        }
-        if (PEAR::isError($error = $this->_socket->disconnect())) {
-            return PEAR::raiseError('Failed to disconnect socket: ' .
-                                    $error->getMessage());
-        }
+        $this->_put('QUIT');
+        $this->_parseResponse(221);
 
-        return true;
+        if (PEAR::isError($error = $this->_socket->disconnect())) {
+            throw new PEAR_Exception('Failed to disconnect socket: ' .
+                                     $error->getMessage());
+        }
     }
 
     /**
      * Attempt to send the EHLO command and obtain a list of ESMTP
      * extensions available, and failing that just send HELO.
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     *
-     * @access private
-     * @since  1.1.0
+     * @throws PEAR_Exception
      */
-    function _negotiate()
+    protected function _negotiate()
     {
-        if (PEAR::isError($error = $this->_put('EHLO', $this->localhost))) {
-            return $error;
-        }
+        $this->_put('EHLO', $this->localhost);
 
-        if (PEAR::isError($this->_parseResponse(250))) {
+        try {
+            $this->_parseResponse(250);
+        } catch (PEAR_Exception $e) {
             /* If we receive a 503 response, we're already authenticated. */
-            if ($this->_code === 503) {
-                return true;
+            if ($e->getCode() === 503) {
+                return;
             }
 
             /* If the EHLO failed, try the simpler HELO command. */
-            if (PEAR::isError($error = $this->_put('HELO', $this->localhost))) {
-                return $error;
-            }
-            if (PEAR::isError($this->_parseResponse(250))) {
-                return PEAR::raiseError('HELO was not accepted: ', $this->_code,
-                                        PEAR_ERROR_RETURN);
-            }
+            $this->_put('HELO', $this->localhost);
+            $this->_parseResponse(250);
 
-            return true;
+            return;
         }
 
         foreach ($this->_arguments as $argument) {
@@ -544,8 +479,6 @@ class Net_SMTP
         if (!isset($this->_esmtp['PIPELINING'])) {
             $this->pipelining = false;
         }
-
-        return true;
     }
 
     /**
@@ -553,12 +486,10 @@ class Net_SMTP
      * has advertised.
      *
      * @return mixed    Returns a string containing the name of the best
-     *                  supported authentication method or a PEAR_Error object
-     *                  if a failure condition is encountered.
-     * @access private
-     * @since  1.1.0
+     *                  supported authentication method.
+     * @throws PEAR_Exception
      */
-    function _getBestAuthMethod()
+    protected function _getBestAuthMethod()
     {
         $available_methods = explode(' ', $this->_esmtp['AUTH']);
 
@@ -568,47 +499,43 @@ class Net_SMTP
             }
         }
 
-        return PEAR::raiseError('No supported authentication methods',
-                                null, PEAR_ERROR_RETURN);
+        throw new PEAR_Exception('No supported authentication methods');
     }
 
     /**
      * Attempt to do SMTP authentication.
      *
-     * @param string The userid to authenticate as.
-     * @param string The password to authenticate with.
-     * @param string The requested authentication method.  If none is
-     *               specified, the best supported method will be used.
-     * @param bool   Flag indicating whether or not TLS should be attempted.
-     * @param string An optional authorization identifier.  If specified, this
-     *               identifier will be used as the authorization proxy.
+     * @param string $uid     The userid to authenticate as.
+     * @param string $pwd     The password to authenticate with.
+     * @param string $method  The requested authentication method.  If none is
+     *                        specified, the best supported method will be
+     *                        used.
+     * @param bool $tls       Flag indicating whether or not TLS should be
+     *                        attempted.
+     * @param string $authz   An optional authorization identifier.  If
+     *                        specified, this identifier will be used as the
+     *                        authorization proxy.
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     * @access public
-     * @since  1.0
+     * @throws PEAR_Exception
      */
-    function auth($uid, $pwd , $method = '', $tls = true, $authz = '')
+    public function auth($uid, $pwd, $method = '', $tls = true, $authz = '')
     {
         /* We can only attempt a TLS connection if one has been requested,
-         * we're running PHP 5.1.0 or later, have access to the OpenSSL 
-         * extension, are connected to an SMTP server which supports the 
-         * STARTTLS extension, and aren't already connected over a secure 
+         * we're running PHP 5.1.0 or later, have access to the OpenSSL
+         * extension, are connected to an SMTP server which supports the
+         * STARTTLS extension, and aren't already connected over a secure
          * (SSL) socket connection. */
         if ($tls && version_compare(PHP_VERSION, '5.1.0', '>=') &&
             extension_loaded('openssl') && isset($this->_esmtp['STARTTLS']) &&
             strncasecmp($this->host, 'ssl://', 6) !== 0) {
             /* Start the TLS connection attempt. */
-            if (PEAR::isError($result = $this->_put('STARTTLS'))) {
-                return $result;
-            }
-            if (PEAR::isError($result = $this->_parseResponse(220))) {
-                return $result;
-            }
+            $this->_put('STARTTLS');
+            $this->_parseResponse(220);
+
             if (PEAR::isError($result = $this->_socket->enableCrypto(true, STREAM_CRYPTO_METHOD_TLS_CLIENT))) {
-                return $result;
+                throw new PEAR_Exception($result->getMessage(), $result);
             } elseif ($result !== true) {
-                return PEAR::raiseError('STARTTLS failed');
+                throw new PEAR_Exception('STARTTLS failed');
             }
 
             /* Send EHLO again to recieve the AUTH string from the
@@ -617,75 +544,58 @@ class Net_SMTP
         }
 
         if (empty($this->_esmtp['AUTH'])) {
-            return PEAR::raiseError('SMTP server does not support authentication');
+            throw new PEAR_Exception('SMTP server does not support authentication');
         }
 
         /* If no method has been specified, get the name of the best
          * supported method advertised by the SMTP server. */
-        if (empty($method)) {
-            if (PEAR::isError($method = $this->_getBestAuthMethod())) {
-                /* Return the PEAR_Error object from _getBestAuthMethod(). */
-                return $method;
-            }
-        } else {
-            $method = strtoupper($method);
-            if (!array_key_exists($method, $this->auth_methods)) {
-                return PEAR::raiseError("$method is not a supported authentication method");
-            }
-        }
-
-        if (!isset($this->auth_methods[$method])) {
-            return PEAR::raiseError("$method is not a supported authentication method");
+        $method = empty($method)
+            ? $this->_getBestAuthMethod()
+            : strtoupper($method);
+        if (!array_key_exists($method, $this->auth_methods)) {
+            throw new PEAR_Exception($method . ' is not a supported authentication method');
         }
 
         if (!is_callable($this->auth_methods[$method], false)) {
-            return PEAR::raiseError("$method authentication method cannot be called");
+            throw new PEAR_Exception($method . ' authentication method cannot be called');
         }
 
         if (is_array($this->auth_methods[$method])) {
             list($object, $method) = $this->auth_methods[$method];
-            $result = $object->{$method}($uid, $pwd, $authz, $this);
+            $object->{$method}($uid, $pwd, $authz, $this);
         } else {
-            $func =  $this->auth_methods[$method];
-            $result = $func($uid, $pwd, $authz, $this);
+            $func = $this->auth_methods[$method];
+            $func($uid, $pwd, $authz, $this);
          }
-
-        /* If an error was encountered, return the PEAR_Error object. */
-        if (PEAR::isError($result)) {
-            return $result;
-        }
-
-        return true;
     }
 
     /**
      * Add a new authentication method.
      *
-     * @param string    The authentication method name (e.g. 'PLAIN')
-     * @param mixed     The authentication callback (given as the name of a 
-     *                  function or as an (object, method name) array).
-     * @param bool      Should the new method be prepended to the list of 
-     *                  available methods?  This is the default behavior, 
-     *                  giving the new method the highest priority.
+     * @param string $name     The authentication method name (e.g. 'PLAIN')
+     * @param mixed $callback  The authentication callback (given as the name
+     *                         of a function or as an (object, method name)
+     *                         array).
+     * @param bool $prepend    Should the new method be prepended to the list
+     *                         of available methods?  This is the default
+     *                         behavior, giving the new method the highest
+     *                         priority.
      *
-     * @return  mixed   True on success or a PEAR_Error object on failure.
-     *
-     * @access public
-     * @since  1.6.0
+     * @throws PEAR_Exception
      */
-    function setAuthMethod($name, $callback, $prepend = true)
+    public function setAuthMethod($name, $callback, $prepend = true)
     {
         if (!is_string($name)) {
-            return PEAR::raiseError('Method name is not a string');
+            throw new InvalidArgumentException('Method name is not a string');
         }
 
         if (!is_string($callback) && !is_array($callback)) {
-            return PEAR::raiseError('Method callback must be string or array');
+            throw new InvalidArgumentException('Method callback must be string or array');
         }
 
-        if (is_array($callback)) {
-            if (!is_object($callback[0]) || !is_string($callback[1]))
-                return PEAR::raiseError('Bad mMethod callback array');
+        if (is_array($callback) &&
+            (!is_object($callback[0]) || !is_string($callback[1]))) {
+            throw new InvalidArgumentException('Bad method callback array');
         }
 
         if ($prepend) {
@@ -694,186 +604,151 @@ class Net_SMTP
         } else {
             $this->auth_methods[$name] = $callback;
         }
-
-        return true;
     }
 
     /**
      * Authenticates the user using the DIGEST-MD5 method.
      *
-     * @param string The userid to authenticate as.
-     * @param string The password to authenticate with.
-     * @param string The optional authorization proxy identifier.
+     * @param string $uid    The userid to authenticate as.
+     * @param string $pwd    The password to authenticate with.
+     * @param string $authz  The optional authorization proxy identifier.
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     * @access private
-     * @since  1.1.0
+     * @throws PEAR_Exception
      */
-    function _authDigest_MD5($uid, $pwd, $authz = '')
+    protected function _authDigest_MD5($uid, $pwd, $authz = '')
     {
-        if (PEAR::isError($error = $this->_put('AUTH', 'DIGEST-MD5'))) {
-            return $error;
-        }
+        $this->_put('AUTH', 'DIGEST-MD5');
+
         /* 334: Continue authentication request */
-        if (PEAR::isError($error = $this->_parseResponse(334))) {
+        try {
+            $this->_parseResponse(334);
+        } catch (PEAR_Exception $e) {
             /* 503: Error: already authenticated */
-            if ($this->_code === 503) {
-                return true;
+            if ($e->getCode() === 503) {
+                return;
             }
-            return $error;
+            throw $e;
         }
 
         $challenge = base64_decode($this->_arguments[0]);
-        $digest = &Auth_SASL::factory('digest-md5');
+        $digest = Auth_SASL::factory('digest-md5');
         $auth_str = base64_encode($digest->getResponse($uid, $pwd, $challenge,
                                                        $this->host, "smtp",
                                                        $authz));
 
-        if (PEAR::isError($error = $this->_put($auth_str))) {
-            return $error;
-        }
+        $this->_put($auth_str);
+
         /* 334: Continue authentication request */
-        if (PEAR::isError($error = $this->_parseResponse(334))) {
-            return $error;
-        }
+        $this->_parseResponse(334);
 
         /* We don't use the protocol's third step because SMTP doesn't
          * allow subsequent authentication, so we just silently ignore
          * it. */
-        if (PEAR::isError($error = $this->_put(''))) {
-            return $error;
-        }
+        $this->_put('');
+
         /* 235: Authentication successful */
-        if (PEAR::isError($error = $this->_parseResponse(235))) {
-            return $error;
-        }
+        $this->_parseResponse(235);
     }
 
     /**
      * Authenticates the user using the CRAM-MD5 method.
      *
-     * @param string The userid to authenticate as.
-     * @param string The password to authenticate with.
-     * @param string The optional authorization proxy identifier.
+     * @param string $uid    The userid to authenticate as.
+     * @param string $pwd    The password to authenticate with.
+     * @param string $authz  The optional authorization proxy identifier.
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     * @access private
-     * @since  1.1.0
+     * @throws PEAR_Exception
      */
-    function _authCRAM_MD5($uid, $pwd, $authz = '')
+    protected function _authCRAM_MD5($uid, $pwd, $authz = '')
     {
-        if (PEAR::isError($error = $this->_put('AUTH', 'CRAM-MD5'))) {
-            return $error;
-        }
+        $this->_put('AUTH', 'CRAM-MD5');
+
         /* 334: Continue authentication request */
-        if (PEAR::isError($error = $this->_parseResponse(334))) {
+        try {
+            $this->_parseResponse(334);
+        } catch (PEAR_Exception $e) {
             /* 503: Error: already authenticated */
-            if ($this->_code === 503) {
-                return true;
+            if ($e->getCode() === 503) {
+                return;
             }
-            return $error;
+            throw $e;
         }
 
         $challenge = base64_decode($this->_arguments[0]);
-        $cram = &Auth_SASL::factory('cram-md5');
+        $cram = Auth_SASL::factory('cram-md5');
         $auth_str = base64_encode($cram->getResponse($uid, $pwd, $challenge));
 
-        if (PEAR::isError($error = $this->_put($auth_str))) {
-            return $error;
-        }
+        $this->_put($auth_str);
 
         /* 235: Authentication successful */
-        if (PEAR::isError($error = $this->_parseResponse(235))) {
-            return $error;
-        }
+        $this->_parseResponse(235);
     }
 
     /**
      * Authenticates the user using the LOGIN method.
      *
-     * @param string The userid to authenticate as.
-     * @param string The password to authenticate with.
-     * @param string The optional authorization proxy identifier.
+     * @param string $uid    The userid to authenticate as.
+     * @param string $pwd    The password to authenticate with.
+     * @param string $authz  The optional authorization proxy identifier.
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     * @access private
-     * @since  1.1.0
+     * @throws PEAR_Exception
      */
-    function _authLogin($uid, $pwd, $authz = '')
+    protected function _authLogin($uid, $pwd, $authz = '')
     {
-        if (PEAR::isError($error = $this->_put('AUTH', 'LOGIN'))) {
-            return $error;
-        }
+        $this->_put('AUTH', 'LOGIN');
+
         /* 334: Continue authentication request */
-        if (PEAR::isError($error = $this->_parseResponse(334))) {
+        try {
+            $this->_parseResponse(334);
+        } catch (PEAR_Exception $e) {
             /* 503: Error: already authenticated */
-            if ($this->_code === 503) {
-                return true;
+            if ($e->getCode() === 503) {
+                return;
             }
-            return $error;
+            throw $e;
         }
 
-        if (PEAR::isError($error = $this->_put(base64_encode($uid)))) {
-            return $error;
-        }
+        $this->_put(base64_encode($uid));
+
         /* 334: Continue authentication request */
-        if (PEAR::isError($error = $this->_parseResponse(334))) {
-            return $error;
-        }
+        $this->_parseResponse(334);
 
-        if (PEAR::isError($error = $this->_put(base64_encode($pwd)))) {
-            return $error;
-        }
+        $this->_put(base64_encode($pwd));
 
         /* 235: Authentication successful */
-        if (PEAR::isError($error = $this->_parseResponse(235))) {
-            return $error;
-        }
-
-        return true;
+        $this->_parseResponse(235);
     }
 
     /**
      * Authenticates the user using the PLAIN method.
      *
-     * @param string The userid to authenticate as.
-     * @param string The password to authenticate with.
-     * @param string The optional authorization proxy identifier.
+     * @param string $uid    The userid to authenticate as.
+     * @param string $pwd    The password to authenticate with.
+     * @param string $authz  The optional authorization proxy identifier.
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     * @access private
-     * @since  1.1.0
+     * @throws PEAR_Exception
      */
-    function _authPlain($uid, $pwd, $authz = '')
+    protected function _authPlain($uid, $pwd, $authz = '')
     {
-        if (PEAR::isError($error = $this->_put('AUTH', 'PLAIN'))) {
-            return $error;
-        }
+        $this->_put('AUTH', 'PLAIN');
+
         /* 334: Continue authentication request */
-        if (PEAR::isError($error = $this->_parseResponse(334))) {
+        try {
+            $this->_parseResponse(334);
+        } catch (PEAR_Exception $e) {
             /* 503: Error: already authenticated */
-            if ($this->_code === 503) {
-                return true;
+            if ($e->getCode() === 503) {
+                return;
             }
-            return $error;
+            throw $e;
         }
 
         $auth_str = base64_encode($authz . chr(0) . $uid . chr(0) . $pwd);
 
-        if (PEAR::isError($error = $this->_put($auth_str))) {
-            return $error;
-        }
+        $this->_put($auth_str);
 
         /* 235: Authentication successful */
-        if (PEAR::isError($error = $this->_parseResponse(235))) {
-            return $error;
-        }
-
-        return true;
+        $this->_parseResponse(235);
     }
 
     /**
@@ -881,31 +756,20 @@ class Net_SMTP
      *
      * @param string The domain name to say we are.
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     * @access public
-     * @since  1.0
+     * @throws PEAR_Exception
      */
-    function helo($domain)
+    public function helo($domain)
     {
-        if (PEAR::isError($error = $this->_put('HELO', $domain))) {
-            return $error;
-        }
-        if (PEAR::isError($error = $this->_parseResponse(250))) {
-            return $error;
-        }
-
-        return true;
+        $this->_put('HELO', $domain);
+        $this->_parseResponse(250);
     }
 
     /**
      * Return the list of SMTP service extensions advertised by the server.
      *
      * @return array The list of SMTP service extensions.
-     * @access public
-     * @since 1.3
      */
-    function getServiceExtensions()
+    public function getServiceExtensions()
     {
         return $this->_esmtp;
     }
@@ -913,78 +777,42 @@ class Net_SMTP
     /**
      * Send the MAIL FROM: command.
      *
-     * @param string $sender    The sender (reverse path) to set.
-     * @param string $params    String containing additional MAIL parameters,
-     *                          such as the NOTIFY flags defined by RFC 1891
-     *                          or the VERP protocol.
+     * @param string $sender  The sender (reverse path) to set.
+     * @param string $params  String containing additional MAIL parameters,
+     *                        such as the NOTIFY flags defined by RFC 1891
+     *                        or the VERP protocol.
      *
-     *                          If $params is an array, only the 'verp' option
-     *                          is supported.  If 'verp' is true, the XVERP
-     *                          parameter is appended to the MAIL command.  If
-     *                          the 'verp' value is a string, the full
-     *                          XVERP=value parameter is appended.
-     *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     * @access public
-     * @since  1.0
+     * @throws PEAR_Exception
      */
-    function mailFrom($sender, $params = null)
+    public function mailFrom($sender, $params = null)
     {
         $args = "FROM:<$sender>";
-
-        /* Support the deprecated array form of $params. */
-        if (is_array($params) && isset($params['verp'])) {
-            /* XVERP */
-            if ($params['verp'] === true) {
-                $args .= ' XVERP';
-
-            /* XVERP=something */
-            } elseif (trim($params['verp'])) {
-                $args .= ' XVERP=' . $params['verp'];
-            }
-        } elseif (is_string($params) && !empty($params)) {
+        if (is_string($params) && strlen($params)) {
             $args .= ' ' . $params;
         }
 
-        if (PEAR::isError($error = $this->_put('MAIL', $args))) {
-            return $error;
-        }
-        if (PEAR::isError($error = $this->_parseResponse(250, $this->pipelining))) {
-            return $error;
-        }
-
-        return true;
+        $this->_put('MAIL', $args);
+        $this->_parseResponse(250, $this->pipelining);
     }
 
     /**
      * Send the RCPT TO: command.
      *
-     * @param string $recipient The recipient (forward path) to add.
-     * @param string $params    String containing additional RCPT parameters,
-     *                          such as the NOTIFY flags defined by RFC 1891.
+     * @param string $recipient  The recipient (forward path) to add.
+     * @param string $params     String containing additional RCPT parameters,
+     *                           such as the NOTIFY flags defined by RFC 1891.
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     *
-     * @access public
-     * @since  1.0
+     * @throws PEAR_Exception
      */
-    function rcptTo($recipient, $params = null)
+    public function rcptTo($recipient, $params = null)
     {
         $args = "TO:<$recipient>";
-        if (is_string($params)) {
+        if (is_string($params) && strlen($params)) {
             $args .= ' ' . $params;
         }
 
-        if (PEAR::isError($error = $this->_put('RCPT', $args))) {
-            return $error;
-        }
-        if (PEAR::isError($error = $this->_parseResponse(array(250, 251), $this->pipelining))) {
-            return $error;
-        }
-
-        return true;
+        $this->_put('RCPT', $args);
+        $this->_parseResponse(array(250, 251), $this->pipelining);
     }
 
     /**
@@ -994,51 +822,49 @@ class Net_SMTP
      * easier overloading for the cases where it is desirable to
      * customize the quoting behavior.
      *
-     * @param string $data  The message text to quote. The string must be passed
-     *                      by reference, and the text will be modified in place.
-     *
-     * @access public
-     * @since  1.2
+     * @param string &$data  The message text to quote. The string must be
+     *                       passed by reference, and the text will be
+     *                       modified in place.
      */
-    function quotedata(&$data)
+    public function quotedata(&$data)
     {
         /* Because a single leading period (.) signifies an end to the
-         * data, legitimate leading periods need to be "doubled" ('..'). */
-        $data = preg_replace('/^\./m', '..', $data);
-
-        /* Change Unix (\n) and Mac (\r) linefeeds into CRLF's (\r\n). */
-        $data = preg_replace('/(?:\r\n|\n|\r(?!\n))/', "\r\n", $data);
+         * data, legitimate leading periods need to be "doubled" ('..').
+         * Also: change Unix (\n) and Mac (\r) linefeeds into CRLF's
+         * (\r\n). */
+        $data = preg_replace(
+            array('/^\./m', '/(?:\r\n|\n|\r(?!\n))/'),
+            array('..', "\r\n"),
+            $data
+        );
     }
 
     /**
      * Send the DATA command.
      *
-     * @param mixed $data     The message data, either as a string or an open
-     *                        file resource.
-     * @param string $headers The message headers.  If $headers is provided,
-     *                        $data is assumed to contain only body data.
+     * @param mixed $data      The message data, either as a string or an open
+     *                         file resource.
+     * @param string $headers  The message headers. If $headers is provided,
+     *                         $data is assumed to contain only body data.
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     * @access public
-     * @since  1.0
+     * @throws PEAR_Exception
      */
-    function data($data, $headers = null)
+    public function data($data, $headers = null)
     {
         /* Verify that $data is a supported type. */
         if (!is_string($data) && !is_resource($data)) {
-            return PEAR::raiseError('Expected a string or file resource');
+            throw new InvalidArgumentException('Expected a string or file resource');
         }
 
         /* Start by considering the size of the optional headers string.  We
          * also account for the addition 4 character "\r\n\r\n" separator
          * sequence. */
-        $size = (is_null($headers)) ? 0 : strlen($headers) + 4;
+        $size = is_null($headers) ? 0 : strlen($headers) + 4;
 
         if (is_resource($data)) {
             $stat = fstat($data);
             if ($stat === false) {
-                return PEAR::raiseError('Failed to get file size');
+                throw new PEAR_Exception('Failed to get file size');
             }
             $size += $stat['size'];
         } else {
@@ -1049,32 +875,26 @@ class Net_SMTP
          * that no fixed maximum message size is in force".  Furthermore, it
          * says that if "the parameter is omitted no information is conveyed
          * about the server's fixed maximum message size". */
-        $limit = (isset($this->_esmtp['SIZE'])) ? $this->_esmtp['SIZE'] : 0;
+        $limit = isset($this->_esmtp['SIZE']) ? $this->_esmtp['SIZE'] : 0;
         if ($limit > 0 && $size >= $limit) {
             $this->disconnect();
-            return PEAR::raiseError('Message size exceeds server limit');
+            throw new PEAR_Exception('Message size exceeds server limit');
         }
 
         /* Initiate the DATA command. */
-        if (PEAR::isError($error = $this->_put('DATA'))) {
-            return $error;
-        }
-        if (PEAR::isError($error = $this->_parseResponse(354))) {
-            return $error;
-        }
+        $this->_put('DATA');
+        $this->_parseResponse(354);
 
         /* If we have a separate headers string, send it first. */
         if (!is_null($headers)) {
             $this->quotedata($headers);
-            if (PEAR::isError($result = $this->_send($headers . "\r\n\r\n"))) {
-                return $result;
-            }
+            $this->_send($headers . "\r\n\r\n");
         }
 
         /* Now we can send the message body data. */
         if (is_resource($data)) {
-            /* Stream the contents of the file resource out over our socket 
-             * connection, line by line.  Each line must be run through the 
+            /* Stream the contents of the file resource out over our socket
+             * connection, line by line.  Each line must be run through the
              * quoting routine. */
             while (strlen($line = fread($data, 8192)) > 0) {
                 /* If the last character is an newline, we need to grab the
@@ -1087,23 +907,17 @@ class Net_SMTP
                     }
                 }
                 $this->quotedata($line);
-                if (PEAR::isError($result = $this->_send($line))) {
-                    return $result;
-                }
+                $this->_send($line);
             }
         } else {
-            /*
-             * Break up the data by sending one chunk (up to 512k) at a time.  
-             * This approach reduces our peak memory usage.
-             */
+            /* Break up the data by sending one chunk (up to 512k) at a time.
+             * This approach reduces our peak memory usage. */
             for ($offset = 0; $offset < $size;) {
                 $end = $offset + 512000;
 
-                /*
-                 * Ensure we don't read beyond our data size or span multiple 
-                 * lines.  quotedata() can't properly handle character data 
-                 * that's split across two line break boundaries.
-                 */
+                /* Ensure we don't read beyond our data size or span multiple
+                 * lines.  quotedata() can't properly handle character data
+                 * that's split across two line break boundaries. */
                 if ($end >= $size) {
                     $end = $size;
                 } else {
@@ -1119,9 +933,7 @@ class Net_SMTP
                 $this->quotedata($chunk);
 
                 /* If we run into a problem along the way, abort. */
-                if (PEAR::isError($result = $this->_send($chunk))) {
-                    return $result;
-                }
+                $this->_send($chunk);
 
                 /* Advance the offset to the end of this chunk. */
                 $offset = $end;
@@ -1129,210 +941,85 @@ class Net_SMTP
         }
 
         /* Finally, send the DATA terminator sequence. */
-        if (PEAR::isError($result = $this->_send("\r\n.\r\n"))) {
-            return $result;
-        }
+        $this->_send("\r\n.\r\n");
 
         /* Verify that the data was successfully received by the server. */
-        if (PEAR::isError($error = $this->_parseResponse(250, $this->pipelining))) {
-            return $error;
-        }
-
-        return true;
+        $this->_parseResponse(250, $this->pipelining);
     }
 
     /**
      * Send the SEND FROM: command.
      *
-     * @param string The reverse path to send.
+     * @param string $path  The reverse path to send.
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     * @access public
-     * @since  1.2.6
+     * @throws PEAR_Exception
      */
-    function sendFrom($path)
+    public function sendFrom($path)
     {
-        if (PEAR::isError($error = $this->_put('SEND', "FROM:<$path>"))) {
-            return $error;
-        }
-        if (PEAR::isError($error = $this->_parseResponse(250, $this->pipelining))) {
-            return $error;
-        }
-
-        return true;
-    }
-
-    /**
-     * Backwards-compatibility wrapper for sendFrom().
-     *
-     * @param string The reverse path to send.
-     *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     *
-     * @access      public
-     * @since       1.0
-     * @deprecated  1.2.6
-     */
-    function send_from($path)
-    {
-        return sendFrom($path);
+        $this->_put('SEND', "FROM:<$path>");
+        $this->_parseResponse(250, $this->pipelining);
     }
 
     /**
      * Send the SOML FROM: command.
      *
-     * @param string The reverse path to send.
+     * @param string $path  The reverse path to send.
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     * @access public
-     * @since  1.2.6
+     * @throws PEAR_Exception
      */
-    function somlFrom($path)
+    public function somlFrom($path)
     {
-        if (PEAR::isError($error = $this->_put('SOML', "FROM:<$path>"))) {
-            return $error;
-        }
-        if (PEAR::isError($error = $this->_parseResponse(250, $this->pipelining))) {
-            return $error;
-        }
-
-        return true;
-    }
-
-    /**
-     * Backwards-compatibility wrapper for somlFrom().
-     *
-     * @param string The reverse path to send.
-     *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     *
-     * @access      public
-     * @since       1.0
-     * @deprecated  1.2.6
-     */
-    function soml_from($path)
-    {
-        return somlFrom($path);
+        $this->_put('SOML', "FROM:<$path>");
+        $this->_parseResponse(250, $this->pipelining);
     }
 
     /**
      * Send the SAML FROM: command.
      *
-     * @param string The reverse path to send.
+     * @param string $path  The reverse path to send.
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     * @access public
-     * @since  1.2.6
+     * @throws PEAR_Exception
      */
-    function samlFrom($path)
+    public function samlFrom($path)
     {
-        if (PEAR::isError($error = $this->_put('SAML', "FROM:<$path>"))) {
-            return $error;
-        }
-        if (PEAR::isError($error = $this->_parseResponse(250, $this->pipelining))) {
-            return $error;
-        }
-
-        return true;
-    }
-
-    /**
-     * Backwards-compatibility wrapper for samlFrom().
-     *
-     * @param string The reverse path to send.
-     *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     *
-     * @access      public
-     * @since       1.0
-     * @deprecated  1.2.6
-     */
-    function saml_from($path)
-    {
-        return samlFrom($path);
+        $this->_put('SAML', "FROM:<$path>");
+        $this->_parseResponse(250, $this->pipelining);
     }
 
     /**
      * Send the RSET command.
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     * @access public
-     * @since  1.0
+     * @throws PEAR_Exception
      */
-    function rset()
+    public function rset()
     {
-        if (PEAR::isError($error = $this->_put('RSET'))) {
-            return $error;
-        }
-        if (PEAR::isError($error = $this->_parseResponse(250, $this->pipelining))) {
-            return $error;
-        }
-
-        return true;
+        $this->_put('RSET');
+        $this->_parseResponse(250, $this->pipelining);
     }
 
     /**
      * Send the VRFY command.
      *
-     * @param string The string to verify
+     * @param string $string  The string to verify
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     * @access public
-     * @since  1.0
+     * @throws PEAR_Exception
      */
-    function vrfy($string)
+    public function vrfy($string)
     {
         /* Note: 251 is also a valid response code */
-        if (PEAR::isError($error = $this->_put('VRFY', $string))) {
-            return $error;
-        }
-        if (PEAR::isError($error = $this->_parseResponse(array(250, 252)))) {
-            return $error;
-        }
-
-        return true;
+        $this->_put('VRFY', $string);
+        $this->_parseResponse(array(250, 252));
     }
 
     /**
      * Send the NOOP command.
      *
-     * @return mixed Returns a PEAR_Error with an error message on any
-     *               kind of failure, or true on success.
-     * @access public
-     * @since  1.0
+     * @throws PEAR_Exception
      */
-    function noop()
+    public function noop()
     {
-        if (PEAR::isError($error = $this->_put('NOOP'))) {
-            return $error;
-        }
-        if (PEAR::isError($error = $this->_parseResponse(250))) {
-            return $error;
-        }
-
-        return true;
-    }
-
-    /**
-     * Backwards-compatibility method.  identifySender()'s functionality is
-     * now handled internally.
-     *
-     * @return  boolean     This method always return true.
-     *
-     * @access  public
-     * @since   1.0
-     */
-    function identifySender()
-    {
-        return true;
+        $this->_put('NOOP');
+        $this->_parseResponse(250);
     }
 
 }

--- a/docs/guide.txt
+++ b/docs/guide.txt
@@ -15,10 +15,10 @@
 Dependencies
 ============
 
-The ``PEAR_Error`` Class
+The ``PEAR_Exception`` Class
 ------------------------
 
-The Net_SMTP package uses the `PEAR_Error`_ class for all of its `error
+The Net_SMTP package uses the `PEAR_Exception`_ object for all of its `error
 handling`_.
 
 The ``Net_Socket`` Package
@@ -37,15 +37,15 @@ be available.
 Error Handling
 ==============
 
-All of the Net_SMTP class's public methods return a PEAR_Error_ object if an
+All of the Net_SMTP class's public methods throw a PEAR_Exception_ object if an
 error occurs.  The standard way to check for a PEAR_Error object is by using
-`PEAR::isError()`_::
+try/catch blocks::
 
-    if (PEAR::isError($error = $smtp->connect())) {
-        die($error->getMessage());
+    try {
+        $smtp->connect();
+    } catch (PEAR_Exception $e) {
+        die($e->getMessage());
     }
-
-.. _PEAR::isError(): http://pear.php.net/manual/en/core.pear.pear.iserror.php
 
 SMTP Authentication
 ===================
@@ -225,31 +225,39 @@ using the Net_SMTP package::
     }
 
     /* Connect to the SMTP server. */
-    if (PEAR::isError($e = $smtp->connect())) {
+    try {
+        $smtp->connect();
+    } catch (PEAR_Exception $e) {
         die($e->getMessage() . "\n");
     }
 
     /* Send the 'MAIL FROM:' SMTP command. */
-    if (PEAR::isError($smtp->mailFrom($from))) {
+    try {
+        $smtp->mailFrom($from);
+    } catch (PEAR_Exception $e) {
         die("Unable to set sender to <$from>\n");
     }
 
     /* Address the message to each of the recipients. */
-    foreach ($rcpt as $to) {
-        if (PEAR::isError($res = $smtp->rcptTo($to))) {
-            die("Unable to add recipient <$to>: " . $res->getMessage() . "\n");
+    try {
+        foreach ($rcpt as $to) {
+            $smtp->rcptTo($to);
         }
+    } catch (PEAR_Exception $e) {
+        die("Unable to add recipient <$to>: " . $e->getMessage() . "\n");
     }
 
     /* Set the body of the message. */
-    if (PEAR::isError($smtp->data($subj . "\r\n" . $body))) {
+    try {
+        $smtp->data($subj . "\r\n" . $body);
+    } catch (PEAR_Exception $e) {
         die("Unable to send data\n");
     }
 
     /* Disconnect from the SMTP server. */
     $smtp->disconnect();
 
-.. _PEAR_Error: http://pear.php.net/manual/en/core.pear.pear-error.php
+.. _PEAR_Exception: http://pear.php.net/manual/en/core.pear.pear-exception.php
 .. _Net_Socket: http://pear.php.net/package/Net_Socket
 .. _Auth_SASL: http://pear.php.net/package/Auth_SASL
 

--- a/examples/basic.php
+++ b/examples/basic.php
@@ -14,24 +14,32 @@ if (! ($smtp = new Net_SMTP($host))) {
 }
 
 /* Connect to the SMTP server. */
-if (PEAR::isError($e = $smtp->connect())) {
+try {
+    $smtp->connect();
+} catch (PEAR_Exception $e) {
     die($e->getMessage() . "\n");
 }
 $smtp->auth('username','password');
 /* Send the 'MAIL FROM:' SMTP command. */
-if (PEAR::isError($smtp->mailFrom($from))) {
+try {
+    $smtp->mailFrom($from);
+} catch (PEAR_Exception $e) {
     die("Unable to set sender to <$from>\n");
 }
 
 /* Address the message to each of the recipients. */
-foreach ($rcpt as $to) {
-    if (PEAR::isError($res = $smtp->rcptTo($to))) {
-        die("Unable to add recipient <$to>: " . $res->getMessage() . "\n");
+try {
+    foreach ($rcpt as $to) {
+        $smtp->rcptTo($to);
     }
+} catch (PEAR_Exception $e) {
+    die("Unable to add recipient <$to>: " . $e->getMessage() . "\n");
 }
 
 /* Set the body of the message. */
-if (PEAR::isError($smtp->data($subj . "\r\n" . $body))) {
+try {
+    $smtp->data($subj . "\r\n" . $body);
+} catch (PEAR_Exception $e) {
     die("Unable to send data\n");
 }
 

--- a/package.xml
+++ b/package.xml
@@ -53,7 +53,7 @@
  <dependencies>
   <required>
    <php>
-    <min>4.0.5</min>
+    <min>5.0.0</min>
    </php>
    <pearinstaller>
     <min>1.4.3</min>

--- a/tests/auth.phpt
+++ b/tests/auth.phpt
@@ -12,23 +12,32 @@ if (! ($smtp = new Net_SMTP(TEST_HOSTNAME, TEST_PORT, TEST_LOCALHOST))) {
 	die("Unable to instantiate Net_SMTP object\n");
 }
 
-if (PEAR::isError($e = $smtp->connect())) {
+try {
+    $e = $smtp->connect();
+} catch (Exception $e) {
 	die($e->getMessage() . "\n");
 }
 
-if (PEAR::isError($e = $smtp->auth(TEST_AUTH_USER, TEST_AUTH_PASS))) {
-}
+try {
+    $smtp->auth(TEST_AUTH_USER, TEST_AUTH_PASS);
+} catch (Exception $e) {}
 
-if (PEAR::isError($smtp->mailFrom(TEST_FROM))) {
+try {
+    $smtp->mailFrom(TEST_FROM);
+} catch (Exception $e) {
 	die('Unable to set sender to <' . TEST_FROM . ">\n");
 }
 
-if (PEAR::isError($res = $smtp->rcptTo(TEST_TO))) {
+try {
+    $smtp->rcptTo(TEST_TO);
+} catch (Exception $e) {
 	die('Unable to add recipient <' . TEST_TO . '>: ' .
-		$res->getMessage() . "\n");
+		$e->getMessage() . "\n");
 }
 
-if (PEAR::isError($smtp->data(TEST_SUBJECT . "\r\n" . TEST_BODY))) {
+try {
+    $smtp->data(TEST_SUBJECT . "\r\n" . TEST_BODY);
+} catch (Exception $e) {
 	die("Unable to send data\n");
 }
 

--- a/tests/basic.phpt
+++ b/tests/basic.phpt
@@ -12,20 +12,28 @@ if (! ($smtp = new Net_SMTP(TEST_HOSTNAME, TEST_PORT, TEST_LOCALHOST))) {
 	die("Unable to instantiate Net_SMTP object\n");
 }
 
-if (PEAR::isError($e = $smtp->connect())) {
+try {
+    $smtp->connect();
+} catch (Exception $e) {
 	die($e->getMessage() . "\n");
 }
 
-if (PEAR::isError($smtp->mailFrom(TEST_FROM))) {
+try {
+    $smtp->mailFrom(TEST_FROM);
+} catch (Exception $e) {
 	die('Unable to set sender to <' . TEST_FROM . ">\n");
 }
 
-if (PEAR::isError($res = $smtp->rcptTo(TEST_TO))) {
+try {
+    $smtp->rcptTo(TEST_TO);
+} catch (Exception $e) {
 	die('Unable to add recipient <' . TEST_TO . '>: ' .
-		$res->getMessage() . "\n");
+		$e->getMessage() . "\n");
 }
 
-if (PEAR::isError($smtp->data(TEST_SUBJECT . "\r\n" . TEST_BODY))) {
+try {
+    $smtp->data(TEST_SUBJECT . "\r\n" . TEST_BODY);
+} catch (Exception $e) {
 	die("Unable to send data\n");
 }
 

--- a/tests/quotedata.phpt
+++ b/tests/quotedata.phpt
@@ -51,9 +51,11 @@ function literal($x)
 }
 
 $error = false;
+$smtp = new Net_SMTP();
+
 foreach ($tests as $input => $expected) {
     $output = $input;
-    Net_SMTP::quotedata($output);
+    $smtp->quotedata($output);
     if ($output != $expected) {
         printf("Error: '%s' => '%s' (expected: '%s')",
             literal($input), literal($output), literal($expected));


### PR DESCRIPTION
Convert to PHP 5 OO style.
Errors are now reported via PEAR_Exceptions.
Removed deprecated commands/parameters.
Gets rid of strict errors when running with PHP 5.4+
