### PR TITLE
missing LICENSE make redistribution impossible

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -36,6 +36,8 @@
  </notes>
  <contents>
   <dir baseinstalldir="/" name="/">
+   <file name="LICENSE" role="doc" />
+   <file name="README.rst" role="doc" />
    <dir name="docs">
     <file name="guide.txt" role="doc" />
    </dir> <!-- /docs -->


### PR DESCRIPTION
Missing LICENSE make downstream redistribution of this package impossible as, from PHP License term

    1. Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.

Please also apply in 1.x branch