### PR TITLE
Fix a forgotten _send() call.

### DIFF
--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -1087,7 +1087,7 @@ class Net_SMTP
         $terminator = (substr($last, -2) == "\r\n" ? '' : "\r\n") . ".\r\n";
 
         /* Finally, send the DATA terminator sequence. */
-        if (PEAR::isError($result = $this->_send($terminator))) {
+        if (PEAR::isError($result = $this->send($terminator))) {
             return $result;
         }
 


### PR DESCRIPTION
Commit b12d2b755d1ea8e73762e4bc65d83aa272125f93 replaced the _send() function by send() but there is still a _send() call.