### PR TITLE
Use valid spdx license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "include-path": [
         "./"
     ],
-    "license": "PHP License",
+    "license": "PHP-3.01",
     "name": "pear/net_smtp",
     "homepage": "http://pear.github.io/Net_SMTP/",
     "support": {


### PR DESCRIPTION
See <https://spdx.org/licenses/>.