### PR TITLE
Don't disconnect when message size exceeds server limit.

### DIFF
--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -1037,7 +1037,6 @@ class Net_SMTP
          * about the server's fixed maximum message size". */
         $limit = (isset($this->esmtp['SIZE'])) ? $this->esmtp['SIZE'] : 0;
         if ($limit > 0 && $size >= $limit) {
-            $this->disconnect();
             return PEAR::raiseError('Message size exceeds server limit');
         }
 


### PR DESCRIPTION
I really see no reason to do this. It's also the only place where
we disconnect on error.