### PR TITLE
GSSAPI: make gssapi_cname optional

### DIFF
--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -918,8 +918,10 @@ class Net_SMTP
 
         try {
             $ccache = new KRB5CCache();
-            $ccache->open($this->gssapi_cname);
-
+            if ($this->gssapi_cname) {
+                $ccache->open($this->gssapi_cname);
+            }
+            
             $gssapicontext = new GSSAPIContext();
             $gssapicontext->acquireCredentials($ccache);
 

--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -912,13 +912,13 @@ class Net_SMTP
             return PEAR::raiseError('No Kerberos service principal set', 2);
         }
 
-        if ($this->gssapi_cname) {
+        if (!empty($this->gssapi_cname)) {
             putenv('KRB5CCNAME=' . $this->gssapi_cname);
         }
 
         try {
             $ccache = new KRB5CCache();
-            if ($this->gssapi_cname) {
+            if (!empty($this->gssapi_cname)) {
                 $ccache->open($this->gssapi_cname);
             }
             

--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -912,11 +912,9 @@ class Net_SMTP
             return PEAR::raiseError('No Kerberos service principal set', 2);
         }
 
-        if (!$this->gssapi_cname) {
-            return PEAR::raiseError('No Kerberos credentials cache set', 2);
+        if ($this->gssapi_cname) {
+            putenv('KRB5CCNAME=' . $this->gssapi_cname);
         }
-
-        putenv('KRB5CCNAME=' . $this->gssapi_cname);
 
         try {
             $ccache = new KRB5CCache();

--- a/docs/guide.txt
+++ b/docs/guide.txt
@@ -72,8 +72,8 @@ GSSAPI
 
 The GSSAPI authentication method uses Kerberos 5 protocol (RFC-4120_).
 Does not use user/password.
-Requires Service Principal ``gssapi_principal`` and
-Credentials Cache ``gssapi_cname`` parameters.
+Requires Service Principal ``gssapi_principal`` parameter and
+has optional Credentials Cache ``gssapi_cname`` parameter.
 Requires DNS and Key Distribution Center (KDC) setup.
 It is considered the most secure method of SMTP authentication.
 

--- a/docs/guide.txt
+++ b/docs/guide.txt
@@ -73,7 +73,7 @@ GSSAPI
 The GSSAPI authentication method uses Kerberos 5 protocol (RFC-4120_).
 Does not use user/password.
 Requires Service Principal ``gssapi_principal`` parameter and
-has optional Credentials Cache ``gssapi_cname`` parameter.
+has an optional Credentials Cache ``gssapi_cname`` parameter.
 Requires DNS and Key Distribution Center (KDC) setup.
 It is considered the most secure method of SMTP authentication.
 


### PR DESCRIPTION
A small fix to GSSAPI support. GSSAPI may be used without gssapi_cname (KRB5CCNAME), since MIT/Heimdal libs have a default value for credentials cache.
https://web.mit.edu/kerberos/krb5-1.12/doc/basic/ccache_def.html#default-ccache-name