### PR TITLE
Implement XOAUTH2 authentication method

### DIFF
--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -208,6 +208,7 @@ class Net_SMTP
         /* These standard authentication methods are always available. */
         $this->setAuthMethod('LOGIN', array($this, 'authLogin'), false);
         $this->setAuthMethod('PLAIN', array($this, 'authPlain'), false);
+        $this->setAuthMethod('XOAUTH2', array($this, 'authXOAuth2'), false);
     }
 
     /**
@@ -960,6 +961,45 @@ class Net_SMTP
         /* 235: Authentication successful */
         if (PEAR::isError($error = $this->parseResponse(235))) {
             return $error;
+        }
+
+        return true;
+    }
+
+    /**
+     * Authenticates the user using the XOAUTH2 method.
+     *
+     * @param string $uid   The userid to authenticate as.
+     * @param string $token The access token to authenticate with.
+     * @param string $authz The optional authorization proxy identifier.
+     *
+     * @return mixed Returns a PEAR_Error with an error message on any
+     *               kind of failure, or true on success.
+     * @since 1.8.2
+     */
+    public function authXOAuth2($uid, $token, $authz, $conn)
+    {
+        $auth = base64_encode("user=$uid\1auth=$token\1\1");
+        if (PEAR::isError($error = $this->put('AUTH', 'XOAUTH2 ' . $auth))) {
+            return $error;
+        }
+
+        /* 235: Authentication successful or 334: Continue authentication */
+        if (PEAR::isError($error = $this->parseResponse([235, 334]))) {
+            return $error;
+        }
+
+        /* 334: Continue authentication request */
+        if ($this->code === 334) {
+            /* Send an empty line as response to 334 */
+            if (PEAR::isError($error = $this->put(''))) {
+                return $error;
+            }
+
+            /* Expect 235: Authentication successful */
+            if (PEAR::isError($error = $this->parseResponse(235))) {
+                return $error;
+            }
         }
 
         return true;

--- a/docs/guide.txt
+++ b/docs/guide.txt
@@ -122,6 +122,12 @@ PLAIN
 The PLAIN authentication method sends the user's password in plain text.
 This method of authentication is not secure and should be avoided.
 
+XOAUTH2
+-----
+
+The XOAUTH2 authentication method sends username and an OAuth2 access token.
+See https://developers.google.com/gmail/imap/xoauth2-protocol#smtp_protocol_exchange
+
 Secure Connections
 ==================
 


### PR DESCRIPTION
Takes an OAuth access token as the passwort argument
to authenticate using the XOAUTH2 mechanism as
suggested by Gmail and Office 365.

Fixes #31

So far tested with Gmail, now submitting for review.