### PR TITLE
BUGFIX: longer tokens violate maximum SMTP command line length

### DIFF
--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -1007,8 +1007,29 @@ class Net_SMTP
     public function authXOAuth2($uid, $token, $authz, $conn)
     {
         $auth = base64_encode("user=$uid\1auth=$token\1\1");
-        if (PEAR::isError($error = $this->put('AUTH', 'XOAUTH2 ' . $auth))) {
-            return $error;
+
+        // Maximum length of the base64-encoded token to be sent in the initial response is 497 bytes, according to
+        // RFC 4954 (https://datatracker.ietf.org/doc/html/rfc4954); for longer tokens an empty initial
+        // response MUST be sent and the token must be sent separately
+        // (497 bytes = 512 bytes /SMTP command length limit/ - 13 bytes /"AUTH XOAUTH2 "/ - 2 bytes /CRLF/)
+        if (strlen($auth) <= 497) {
+            if (PEAR::isError($error = $this->put('AUTH', 'XOAUTH2 ' . $auth))) {
+                return $error;
+            }
+        } else {
+            if (PEAR::isError($error = $this->put('AUTH', 'XOAUTH2'))) {
+                return $error;
+            }
+
+            // server is expected to respond with 334
+            if (PEAR::isError($error = $this->parseResponse(334))) {
+                return $error;
+            }
+
+            // then follows the token
+            if (PEAR::isError($error = $this->put($auth))) {
+                return $error;
+            }
         }
 
         /* 235: Authentication successful or 334: Continue authentication */


### PR DESCRIPTION
This BUGFIX for issue https://github.com/pear/Net_SMTP/issues/69 fixes the case when the XOAuth2 is longer than 497 bytes. Such tokens must not be sent in the initial response (the `AUTH XOAUTH2 <token>` command), but rather send an empty initial response (`AUTH XOAUTH2`), waiting for the server to reply with 334 and then sending the token. (https://datatracker.ietf.org/doc/html/rfc4954)

