### PR TITLE
Add SCRAM-SHA-1, SCRAM-SHA-224, SCRAM-SHA-256, SCRAM-SHA-384 and SCRAM-SHA-512 support

### DIFF
--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -796,8 +796,7 @@ class Net_SMTP
             return $error;
         }
 
-        $auth_sasl = new Auth_SASL;
-        $digest    = $auth_sasl->factory('digest-md5');
+        $digest    = Auth_SASL::factory('digest-md5');
         $challenge = base64_decode($this->arguments[0]);
         $auth_str  = base64_encode(
             $digest->getResponse($uid, $pwd, $challenge, $this->host, "smtp", $authz)
@@ -852,9 +851,8 @@ class Net_SMTP
             return $error;
         }
 
-        $auth_sasl = new Auth_SASL;
         $challenge = base64_decode($this->arguments[0]);
-        $cram      = $auth_sasl->factory('cram-md5');
+        $cram      = Auth_SASL::factory('cram-md5');
         $auth_str  = base64_encode($cram->getResponse($uid, $pwd, $challenge));
 
         if (PEAR::isError($error = $this->put($auth_str))) {
@@ -1214,8 +1212,7 @@ class Net_SMTP
             return $error;
         }
 
-        $auth_sasl = new Auth_SASL;
-        $cram      = $auth_sasl->factory($this->scram_sha_hash_algorithm);
+        $cram      = Auth_SASL::factory($this->scram_sha_hash_algorithm);
         $auth_str  = base64_encode($cram->getResponse($uid, $pwd));
 
         /* Step 1: Send first authentication request */

--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -777,6 +777,7 @@ class Net_SMTP
      * @return mixed Returns a PEAR_Error with an error message on any
      *               kind of failure, or true on success.
      * @since 1.1.0
+     * @deprecated 1.11.0
      */
     protected function authDigestMD5($uid, $pwd, $authz = '')
     {
@@ -829,6 +830,7 @@ class Net_SMTP
      * @return mixed Returns a PEAR_Error with an error message on any
      *               kind of failure, or true on success.
      * @since 1.1.0
+     * @deprecated 1.11.0
      */
     protected function authCRAMMD5($uid, $pwd, $authz = '')
     {
@@ -869,6 +871,7 @@ class Net_SMTP
      * @return mixed Returns a PEAR_Error with an error message on any
      *               kind of failure, or true on success.
      * @since 1.1.0
+     * @deprecated 1.11.0
      */
     protected function authLogin($uid, $pwd, $authz = '')
     {
@@ -914,6 +917,7 @@ class Net_SMTP
      * @return mixed Returns a PEAR_Error with an error message on any
      *               kind of failure, or true on success.
      * @since 1.1.0
+     * @deprecated 1.11.0
      */
     protected function authPlain($uid, $pwd, $authz = '')
     {

--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -781,6 +781,8 @@ class Net_SMTP
      */
     protected function authDigestMD5($uid, $pwd, $authz = '')
     {
+        trigger_error(__CLASS__ . ' (' . $this->host . '): Authentication method DIGEST-MD5 is no longer secure and should be avoided.', E_USER_DEPRECATED);
+
         if (PEAR::isError($error = $this->put('AUTH', 'DIGEST-MD5'))) {
             return $error;
         }
@@ -834,6 +836,8 @@ class Net_SMTP
      */
     protected function authCRAMMD5($uid, $pwd, $authz = '')
     {
+        trigger_error(__CLASS__ . ' (' . $this->host . '): Authentication method CRAM-MD5 is no longer secure and should be avoided.', E_USER_DEPRECATED);
+
         if (PEAR::isError($error = $this->put('AUTH', 'CRAM-MD5'))) {
             return $error;
         }
@@ -875,6 +879,8 @@ class Net_SMTP
      */
     protected function authLogin($uid, $pwd, $authz = '')
     {
+        trigger_error(__CLASS__ . ' (' . $this->host . '): Authentication method LOGIN is no longer secure and should be avoided.', E_USER_DEPRECATED);
+
         if (PEAR::isError($error = $this->put('AUTH', 'LOGIN'))) {
             return $error;
         }
@@ -921,6 +927,8 @@ class Net_SMTP
      */
     protected function authPlain($uid, $pwd, $authz = '')
     {
+        trigger_error(__CLASS__ . ' (' . $this->host . '): Authentication method PLAIN is no longer secure and should be avoided.', E_USER_DEPRECATED);
+
         if (PEAR::isError($error = $this->put('AUTH', 'PLAIN'))) {
             return $error;
         }

--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -781,7 +781,8 @@ class Net_SMTP
      */
     protected function authDigestMD5($uid, $pwd, $authz = '')
     {
-        trigger_error(__CLASS__ . ' (' . $this->host . '): Authentication method DIGEST-MD5 is no longer secure and should be avoided.', E_USER_DEPRECATED);
+        trigger_error(__CLASS__ . ' (' . $this->host . '): Authentication method DIGEST-MD5' .
+            ' is no longer secure and should be avoided.', E_USER_DEPRECATED);
 
         if (PEAR::isError($error = $this->put('AUTH', 'DIGEST-MD5'))) {
             return $error;
@@ -836,7 +837,8 @@ class Net_SMTP
      */
     protected function authCRAMMD5($uid, $pwd, $authz = '')
     {
-        trigger_error(__CLASS__ . ' (' . $this->host . '): Authentication method CRAM-MD5 is no longer secure and should be avoided.', E_USER_DEPRECATED);
+        trigger_error(__CLASS__ . ' (' . $this->host . '): Authentication method CRAM-MD5' .
+            ' is no longer secure and should be avoided.', E_USER_DEPRECATED);
 
         if (PEAR::isError($error = $this->put('AUTH', 'CRAM-MD5'))) {
             return $error;
@@ -879,7 +881,8 @@ class Net_SMTP
      */
     protected function authLogin($uid, $pwd, $authz = '')
     {
-        trigger_error(__CLASS__ . ' (' . $this->host . '): Authentication method LOGIN is no longer secure and should be avoided.', E_USER_DEPRECATED);
+        trigger_error(__CLASS__ . ' (' . $this->host . '): Authentication method LOGIN' .
+            ' is no longer secure and should be avoided.', E_USER_DEPRECATED);
 
         if (PEAR::isError($error = $this->put('AUTH', 'LOGIN'))) {
             return $error;
@@ -927,7 +930,8 @@ class Net_SMTP
      */
     protected function authPlain($uid, $pwd, $authz = '')
     {
-        trigger_error(__CLASS__ . ' (' . $this->host . '): Authentication method PLAIN is no longer secure and should be avoided.', E_USER_DEPRECATED);
+        trigger_error(__CLASS__ . ' (' . $this->host . '): Authentication method PLAIN' .
+            ' is no longer secure and should be avoided.', E_USER_DEPRECATED);
 
         if (PEAR::isError($error = $this->put('AUTH', 'PLAIN'))) {
             return $error;

--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -924,13 +924,9 @@ class Net_SMTP
      * @return mixed Returns a PEAR_Error with an error message on any
      *               kind of failure, or true on success.
      * @since 1.1.0
-     * @deprecated 1.11.0
      */
     protected function authPlain($uid, $pwd, $authz = '')
     {
-        trigger_error(__CLASS__ . ' (' . $this->host . '): Authentication method PLAIN' .
-            ' is no longer secure and should be avoided.', E_USER_DEPRECATED);
-
         if (PEAR::isError($error = $this->put('AUTH', 'PLAIN'))) {
             return $error;
         }

--- a/README.rst
+++ b/README.rst
@@ -127,11 +127,11 @@ trivial.
 
 .. _Base64: https://www.php.net/manual/en/function.base64-encode.php
 
-PLAIN (DEPRECATED)
+PLAIN
 -----
 
-**DEPRECATED**
-This authentication method is no longer secure and should be avoided.
+This authentication method is no longer secure and should only be used
+local or via an TLS encrypted connection.
 
 The PLAIN authentication method sends the user's password in plain text.
 

--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,35 @@ methods, in order of preference:
 
 .. _RFC-2554: https://www.ietf.org/rfc/rfc2554.txt
 
+CRAM-MD5 (DEPRECATED)
+--------
+
+**DEPRECATED**
+This authentication method is no longer secure.
+
+The CRAM-MD5 authentication method has been superseded by the DIGEST-MD5_
+method in terms of security.  It is provided here for compatibility with
+older SMTP servers that may not support the newer DIGEST-MD5 algorithm.
+
+**Note:** The CRAM-MD5 authentication method is only supported if the
+AUTH_SASL_ package is available.
+
+DIGEST-MD5 (DEPRECATED)
+----------
+
+**DEPRECATED**
+This authentication method is no longer secure.
+
+The DIGEST-MD5 authentication method uses `RSA Data Security Inc.`_'s MD5
+Message Digest algorithm.  It is considered a more secure method of SMTP
+authentication than PLAIN or LOGIN, while still vulnerable to MitM attacks
+without TLS/SSL.
+
+**Note:** The DIGEST-MD5 authentication method is only supported if the
+AUTH_SASL_ package is available.
+
+.. _RSA Data Security Inc.: https://www.rsasecurity.com/
+
 GSSAPI
 ------
 
@@ -86,42 +115,6 @@ if the krb5_ php extension is available.
 .. _RFC-4120: https://tools.ietf.org/html/rfc4120
 .. _krb5: https://pecl.php.net/package/krb5
 
-DIGEST-MD5
-----------
-
-The DIGEST-MD5 authentication method uses `RSA Data Security Inc.`_'s MD5
-Message Digest algorithm.  It is considered a more secure method of SMTP
-authentication than PLAIN or LOGIN, while still vulnerable to MitM attacks
-without TLS/SSL.
-
-**Note:** The DIGEST-MD5 authentication method is only supported if the
-AUTH_SASL_ package is available.
-
-.. _RSA Data Security Inc.: https://www.rsasecurity.com/
-
-CRAM-MD5
---------
-
-The CRAM-MD5 authentication method has been superseded by the DIGEST-MD5_
-method in terms of security.  It is provided here for compatibility with
-older SMTP servers that may not support the newer DIGEST-MD5 algorithm.
-
-**Note:** The CRAM-MD5 authentication method is only supported if the
-AUTH_SASL_ package is available.
-
-SCRAM-SHA
---------
-
-In cryptography, the Salted Challenge Response Authentication Mechanism (SCRAM)
-is a family of modern, password-based challenge–response authentication mechanisms
-providing authentication to a server.
-
-Available mechanisms are SCRAM-SHA-1, SCRAM-SHA-224, SCRAM-SHA-256, SCRAM-SHA-384
-and SCRAM-SHA-512.
-
-**Note:** The SCRAM-SHA authentication method is only supported if the
-AUTH_SASL_ package is available.
-
 LOGIN
 -----
 
@@ -137,6 +130,19 @@ PLAIN
 
 The PLAIN authentication method sends the user's password in plain text.
 This method of authentication is not secure and should be avoided.
+
+SCRAM
+--------
+
+In cryptography, the Salted Challenge Response Authentication Mechanism (SCRAM)
+is a family of modern, password-based challenge–response authentication mechanisms
+providing authentication to a server.
+
+Available mechanisms are SCRAM-SHA-1, SCRAM-SHA-224, SCRAM-SHA-256, SCRAM-SHA-384
+and SCRAM-SHA-512.
+
+**Note:** The SCRAM-SHA authentication method is only supported if the
+AUTH_SASL_ package is available.
 
 XOAUTH2
 -------

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@
  User Documentation
 --------------------
 
-:Author:    Jon Parise
-:Contact:   jon@php.net
+:Author:    Jon Parise, Armin Graefe
+:Contact:   jon@php.net, schengawegga@gmail.com
 
 .. contents:: Table of Contents
 .. section-numbering::
@@ -41,9 +41,9 @@ The ``Auth_SASL`` Package
 -------------------------
 
 The `Auth_SASL`_ package is an optional dependency.  If it is available, the
-Net_SMTP package will be able to support the DIGEST-MD5_ and CRAM-MD5_ SMTP
-authentication methods.  Otherwise, only the LOGIN_ and PLAIN_ methods will
-be available.
+Net_SMTP package will be able to support the DIGEST-MD5_, CRAM-MD5_ and
+SCRAM-SHA_ SMTP authentication methods. Otherwise, only the LOGIN_ and
+PLAIN_ methods will be available.
 
 Error Handling
 ==============
@@ -104,6 +104,19 @@ method in terms of security.  It is provided here for compatibility with
 older SMTP servers that may not support the newer DIGEST-MD5 algorithm.
 
 **Note:** The CRAM-MD5 authentication method is only supported if the
+AUTH_SASL_ package is available.
+
+SCRAM-SHA
+--------
+
+In cryptography, the Salted Challenge Response Authentication Mechanism (SCRAM)
+is a family of modern, password-based challenge–response authentication mechanisms
+providing authentication to a server.
+
+Available mechanisms are SCRAM-SHA-1, SCRAM-SHA-224, SCRAM-SHA-256, SCRAM-SHA-384
+and SCRAM-SHA-512.
+
+**Note:** The SCRAM-SHA authentication method is only supported if the
 AUTH_SASL_ package is available.
 
 LOGIN

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@
  User Documentation
 --------------------
 
-:Author:    Jon Parise, Armin Graefe
-:Contact:   jon@php.net, schengawegga@gmail.com
+:Author:    "Jon Parise", "Armin Graefe"
+:Contact:   "jon@php.net", "schengawegga@gmail.com"
 
 .. contents:: Table of Contents
 .. section-numbering::

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,11 @@
  User Documentation
 --------------------
 
-:Author:    "Jon Parise", "Armin Graefe"
-:Contact:   "jon@php.net", "schengawegga@gmail.com"
++--------+-----------+----------------------+
+|Author: |Jon Parise |Armin Graefe          |
++--------+-----------+----------------------+
+|Contact:|jon@php.net|schengawegga@gmail.com|
++--------+-----------+----------------------+
 
 .. contents:: Table of Contents
 .. section-numbering::

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ CRAM-MD5 (DEPRECATED)
 --------
 
 **DEPRECATED**
-This authentication method is no longer secure.
+This authentication method is no longer secure and should be avoided.
 
 The CRAM-MD5 authentication method has been superseded by the DIGEST-MD5_
 method in terms of security.  It is provided here for compatibility with
@@ -87,7 +87,7 @@ DIGEST-MD5 (DEPRECATED)
 ----------
 
 **DEPRECATED**
-This authentication method is no longer secure.
+This authentication method is no longer secure and should be avoided.
 
 The DIGEST-MD5 authentication method uses `RSA Data Security Inc.`_'s MD5
 Message Digest algorithm.  It is considered a more secure method of SMTP
@@ -115,21 +115,25 @@ if the krb5_ php extension is available.
 .. _RFC-4120: https://tools.ietf.org/html/rfc4120
 .. _krb5: https://pecl.php.net/package/krb5
 
-LOGIN
+LOGIN (DEPRECATED)
 -----
+
+**DEPRECATED**
+This authentication method is no longer secure and should be avoided.
 
 The LOGIN authentication method encrypts the user's password using the
 Base64_ encoding scheme.  Because decrypting a Base64-encoded string is
-trivial, LOGIN is not considered a secure authentication method and should
-be avoided.
+trivial.
 
 .. _Base64: https://www.php.net/manual/en/function.base64-encode.php
 
-PLAIN
+PLAIN (DEPRECATED)
 -----
 
+**DEPRECATED**
+This authentication method is no longer secure and should be avoided.
+
 The PLAIN authentication method sends the user's password in plain text.
-This method of authentication is not secure and should be avoided.
 
 SCRAM
 --------


### PR DESCRIPTION
Added SCRAM-SHA-1, SCRAM-SHA-224, SCRAM-SHA-256, SCRAM-SHA-384 and SCRAM-SHA-512 support.
SCRAM-*-PLUS support is at the moment not possible, because pear/Auth_SASL not supports -PLUS features at the moment.
To work well on PHP8 and above, a PR on pear/Auth_SASL is needed: pear/Auth_SASL#6